### PR TITLE
Changed traceback repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "ain2": "1.2.x",
-    "traceback": "0.3.x",
+    "traceback": "git+https://github.com/JulianHH/traceback.git"
     "underscore": "1.4.x"
   }
 }


### PR DESCRIPTION
Traceback has an issue when used in a "use strict" environment. See https://github.com/iriscouch/traceback/issues/3

The changed repo has a fix but the PR has not been merged yet.
